### PR TITLE
Add liquid glass shader distortion

### DIFF
--- a/src/shaders/cube.frag
+++ b/src/shaders/cube.frag
@@ -1,5 +1,12 @@
 #version 450
 
+layout(binding = 0) uniform UniformBufferObject {
+    mat4 model;
+    mat4 view;
+    mat4 proj;
+    vec4 params;
+} ubo;
+
 layout(location = 0) in vec3 worldPos;
 layout(location = 0) out vec4 outColor;
 
@@ -8,8 +15,11 @@ float rand(vec2 co) {
 }
 
 void main() {
-    vec3 normal = normalize(cross(dFdx(worldPos), dFdy(worldPos)));
-    vec2 coord = gl_FragCoord.xy + normal.xy * 10.0;
-    float n = rand(floor(coord / 20.0));
-    outColor = vec4(vec3(n), 0.3);
+    vec2 disp = worldPos.xy - ubo.params.xy;
+    float r2 = dot(disp, disp);
+    float falloff = max(0.0, 1.0 - r2);
+    vec2 refracted = gl_FragCoord.xy + disp * falloff * ubo.params.z * 100.0;
+    float n = rand(floor(refracted / 20.0));
+    float edge = smoothstep(0.9, 1.0, length(disp));
+    outColor = vec4(vec3(n), 0.3) + vec4(edge);
 }

--- a/src/shaders/cube.vert
+++ b/src/shaders/cube.vert
@@ -4,6 +4,7 @@ layout(binding = 0) uniform UniformBufferObject {
     mat4 model;
     mat4 view;
     mat4 proj;
+    vec4 params;
 } ubo;
 
 layout(location = 0) in vec3 inPosition;

--- a/src/vulkan_app/buffers.rs
+++ b/src/vulkan_app/buffers.rs
@@ -152,7 +152,8 @@ impl VulkanApp {
         );
         proj[1][1] *= -1.0;
 
-        let ubo = UniformBufferObject { model, view, proj };
+        let params = [0.5, 0.5, 0.1, 0.0];
+        let ubo = UniformBufferObject { model, view, proj, params };
 
         unsafe {
             let data_ptr = self

--- a/src/vulkan_app/descriptors.rs
+++ b/src/vulkan_app/descriptors.rs
@@ -7,7 +7,7 @@ pub fn create_descriptor_set_layout(device: &ash::Device) -> vk::DescriptorSetLa
         .binding(0)
         .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
         .descriptor_count(1)
-        .stage_flags(vk::ShaderStageFlags::VERTEX)
+        .stage_flags(vk::ShaderStageFlags::VERTEX | vk::ShaderStageFlags::FRAGMENT)
         .build();
 
     let layout_info = vk::DescriptorSetLayoutCreateInfo::builder()

--- a/src/vulkan_app/utils.rs
+++ b/src/vulkan_app/utils.rs
@@ -32,6 +32,7 @@ pub struct UniformBufferObject {
     pub model: Matrix4<f32>,
     pub view: Matrix4<f32>,
     pub proj: Matrix4<f32>,
+    pub params: [f32; 4],
 }
 
 pub unsafe extern "system" fn vulkan_debug_callback(


### PR DESCRIPTION
## Summary
- extend uniform data with params for glass effect
- update cube shaders to use the extra values and distort the background noise
- pass uniform buffer to fragment stage

## Testing
- `cargo check` *(fails: build cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_688a52747f908322b514d134d3d058b4